### PR TITLE
Headers now passed from config if using crumb

### DIFF
--- a/src/Smithers.js
+++ b/src/Smithers.js
@@ -11,7 +11,7 @@ class Smithers {
         this.config = config || {};
 
         if (this.config.crumbIssuer) {
-            this.config.headers = {};
+            this.config.headers = this.config.headers || {};
             this.init = new Promise((resolve, reject) => {
                 crumbIssuer(this.url, this.config).then((crumbResponse) => {
                     const { crumb, crumbRequestField } = crumbResponse;


### PR DESCRIPTION
Headers were previously getting wiped if provided in the instance config.  They are now preserved and passed in the Jenkins request